### PR TITLE
Disable sqlx prepared statements

### DIFF
--- a/welds-connections/src/postgres/mod.rs
+++ b/welds-connections/src/postgres/mod.rs
@@ -67,7 +67,7 @@ impl Client for PostgresClient {
         sql: &str,
         params: &[&(dyn Param + Sync + Send)],
     ) -> Result<ExecuteResult> {
-        let mut query = sqlx::query::<Postgres>(sql);
+        let mut query = sqlx::query::<Postgres>(sql).persistent(false);
         for param in params {
             query = PostgresParam::add_param(*param, query);
         }
@@ -82,7 +82,7 @@ impl Client for PostgresClient {
         sql: &str,
         params: &[&(dyn Param + Sync + Send)],
     ) -> Result<Vec<Row>> {
-        let mut query = sqlx::query::<Postgres>(sql);
+        let mut query = sqlx::query::<Postgres>(sql).persistent(false);
         for param in params {
             query = PostgresParam::add_param(*param, query);
         }
@@ -100,7 +100,7 @@ impl Client for PostgresClient {
         for fetch in fetches {
             let sql = fetch.sql;
             let params = fetch.params;
-            let mut query = sqlx::query::<Postgres>(sql);
+            let mut query = sqlx::query::<Postgres>(sql).persistent(false);
             for param in params {
                 query = PostgresParam::add_param(*param, query);
             }


### PR DESCRIPTION
See [Slack thread](https://membrane-io.slack.com/archives/C1237JZQT/p1745609903760139).

TL;DR - I'm seeing some `prepared statement "sqlx_s_<n>" already exists` errors from sys-db when testing with a postgres db on supabase. sqlx's use of prepared statements can cause problems with connection pooling (e.g. via pgbouncer), [apparently](https://github.com/launchbadge/sqlx/blob/main/FAQ.md?plain=1#L246).

Setting `persistent(false)` across the board like this smells like overkill—maybe instead we should add a param for whether the connection is direct or pooled and only disable persistence (i.e. prepared statements) for pooled?